### PR TITLE
the passportSetup file is required for linkedin auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const passport = require('passport');
 const session = require('express-session');
-// const passportSetup = require('./config/passportSetup');
+const passportSetup = require('./config/passportSetup');
 const knexSessionStore = require('connect-session-knex')(session);
 
 const config = require('./database/dbConfig');


### PR DESCRIPTION
this was commented out and is required for linkedin auth strategy

## PR TITLE
**Description:** <!-- add description here -->
  <!-- What was changed? -->
The passport setup was commented out but it is required for linkedin auth
  <!-- Why does PR exist? -->
To resolve the commented out passport setup
  <!-- How do your changes do what is intended? -->
They bring back in the passport setup config
  <!-- Will a screenshot be helpful? -->
no

### Tests
  <!-- Do we need tests? -->
